### PR TITLE
adding parallelisation for incidence2 method

### DIFF
--- a/R/asmodee.R
+++ b/R/asmodee.R
@@ -265,6 +265,11 @@ asmodee.data.frame <- function(data,
 #' @export
 #'
 #' @rdname asmodee
+#'
+#' @param n_cores An `integer` indicating the number of cores to be used; if
+#'   greater than 1, then asmodee will be run in parallel across the number of
+#'   requested cores; defaults to 1.
+#' 
 asmodee.incidence2 <- function(data,
                                models,
                                alpha = 0.05,
@@ -275,6 +280,7 @@ asmodee.incidence2 <- function(data,
                                uncertain = FALSE,
                                include_warnings = FALSE,
                                force_positive = TRUE,
+                               n_cores = 1,
                                ...) {
   # check incidence2 package is present
   check_suggests("incidence2")
@@ -288,7 +294,9 @@ asmodee.incidence2 <- function(data,
   }
   date_index <- incidence2::get_dates_name(data)
 
-  out <- lapply(split_dat,
+  # Note: with mc.cores = 1, mclapply is simply a lapply, so we do not need a
+  # switch behaviour here.
+  out <- parallel::mclapply(split_dat,
                 asmodee.data.frame,
                 models = models,
                 date_index = date_index,
@@ -300,7 +308,10 @@ asmodee.incidence2 <- function(data,
                 simulate_pi = simulate_pi,
                 uncertain = uncertain,
                 force_positive = force_positive,
-                ...)
+                ...,
+                mc.cores = n_cores
+                )
+  
 
   names(out) <- names(split_dat)
   class(out) <- "trendbreaker_incidence2"

--- a/man/asmodee.Rd
+++ b/man/asmodee.Rd
@@ -35,6 +35,7 @@ asmodee(data, models, ...)
   uncertain = FALSE,
   include_warnings = FALSE,
   force_positive = TRUE,
+  n_cores = 1,
   ...
 )
 }
@@ -91,6 +92,10 @@ to be positive (or zero); can be useful when using Gaussian models for
 count data, to censore confidence or prediction intervals and avoid
 negative predictions. Defaults to \code{FALSE} for general \code{data.frame} inputs,
 and to \code{TRUE} for \code{incidence2} objects.}
+
+\item{n_cores}{An \code{integer} indicating the number of cores to be used; if
+greater than 1, then asmodee will be run in parallel across the number of
+requested cores; defaults to 1.}
 }
 \value{
 An \code{trendbreaker} object (S3 class inheriting \code{list}), containing items


### PR DESCRIPTION
So, this is ultra simple, but does the trick on non-windows machines; not sure how it will fare for windows systems, I suspect n_cores > 1 will issue an error. Old code, but here is an alternative that might still work:
https://github.com/thibautjombart/outbreaker/blob/master/R/interface.R#L664

Might still be worth getting this one through as a first quick pass, as with the defaults it should not break anything? Let me know what you think